### PR TITLE
ellipseError should be an int

### DIFF
--- a/graphics.nim
+++ b/graphics.nim
@@ -363,7 +363,7 @@ proc drawEllipse*(sur: PSurface, cx, cy, xRadius, yRadius: Natural,
   var
     x, y: Natural
     xChange, yChange: int
-    ellipseError: Natural
+    ellipseError: int
     twoASquare, twoBSquare: Natural
     stoppingX, stoppingY: Natural
 


### PR DESCRIPTION
I encountered the problem when trying to run graphics.nim as main module.

It crashed when trying to draw an ellipse, and that came from 

`inc(ellipseError, xChange)`

which computes a negative value for ellipseError.
